### PR TITLE
Added utility to crawl + compare runs

### DIFF
--- a/spot_the_difference.py
+++ b/spot_the_difference.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+
+from argparse import ArgumentParser
+
+import os.path as op
+import numpy as np
+import hashlib
+import json
+import os
+import re
+
+
+def get_seq_steplist(dirs):
+    if not isinstance(dirs, list):
+        dirs = [dirs]
+
+    r = re.compile('.+_[0-9]+$')
+    fl_lists = []
+    for di in dirs:
+        fls = sorted(os.listdir(di))
+        fls_filtered = [f for f in fls if r.match(f)]
+        fl_inds = [int(_.split('_')[-1]) for _ in fls_filtered]
+
+        fls_sorted = [fls_filtered[_] for _ in np.argsort(fl_inds)]
+
+        fl_lists += [fls_sorted]
+    return fl_lists
+
+
+def prune_and_match(file_lists):
+    ref = file_lists[0]
+    new_flist = [ref]
+    for flist in file_lists[1:]:
+        new_flist += [ [item for item in flist if item in ref]  ] 
+    return new_flist
+
+
+def find_outputs(dir_path):
+    try:
+        with open(op.join(dir_path, "_report/report.rst")) as fhandle:
+            summary = fhandle.read()
+    except FileNotFoundError:
+        return {}
+
+    summary = summary.split('\n\n\n')
+    outp_loc = [1 + idx
+                for idx, row in enumerate(summary)
+                if 'Execution Outputs' in row][0]
+    outputs = summary[outp_loc].split('\n')
+
+    kys = [op.split()[1] for op in outputs]
+    vls = [" ".join(op.split()[3:]) for op in outputs]
+
+    fls = {}
+    for k, v in zip(kys, vls):
+        if v == '<undefined>':
+            continue
+        if v.startswith('['):
+            v = json.loads(v.replace("'", '"'))
+        else:
+            v = [v]
+
+        v = [op.basename(_) for _ in v]
+        # Build the dictionary in reverse to easily look up output names
+        for _ in v:
+            fls[_] = k
+
+    return fls
+
+
+def md5_compare(comparable_steps, basepath, path_mods):
+    ref_list, ref_mod = comparable_steps[0], path_mods[0]
+    hash_dict = {}
+    for idx, fdirs in enumerate(comparable_steps):
+        if idx == 0:
+            dk = 'ref'
+            setting = "Reference"
+        else:
+            dk = 'test' + str(idx)
+            setting = "Test " + str(idx)
+
+        hash_dict[dk] = {}
+        print('Computing hashes for {0}...'.format(setting))
+        
+        for fdir in fdirs:
+            fpath = op.join(basepath, path_mods[idx], fdir)
+            outputs = find_outputs(fpath)
+
+            hash_dict[dk][fdir] = {}
+            for key in outputs.keys():
+                tmp_fl = op.join(fpath, key)
+                if op.exists(tmp_fl):
+                    hash_dict[dk][fdir][outputs[key]] = md5(tmp_fl)
+
+    return hash_dict
+
+
+def md5(fl):
+    # From:
+    #  https://stackoverflow.com/questions/22058048/hashing-a-file-in-python
+    # BUF_SIZE is totally arbitrary, change for your app!
+    BUF_SIZE = 65536  # lets read stuff in 64kb chunks!
+    md5 = hashlib.md5()
+
+    with open(fl, 'rb') as f:
+        while True:
+            data = f.read(BUF_SIZE)
+            if not data:
+                break
+            md5.update(data)
+
+    return md5.hexdigest()
+
+
+def flag_differences(file_hashes):
+    tests = set(file_hashes.keys()) - set(['ref'])
+    print("Comparing hashes...")
+    for key in file_hashes['ref'].keys():
+        rdat = file_hashes['ref'][key]
+        print("  Comparing {0}...".format(key))
+        for t in tests:
+            tdat = file_hashes[t][key]
+            print("    {0}:".format(t.capitalize()), end='\t')
+
+            diff = []
+            for k in rdat.keys():
+                if rdat[k] == {}:
+                    diff += ["no data"]
+                elif rdat[k] == tdat[k]:
+                    continue
+                else:
+                    diff += [k]
+            if len(diff) == 0:
+                diff = "SUCCESS!"
+            else:
+                diff = "FAILED for " +  ", ".join(diff)
+
+            print(diff)
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("ref", help="Working directory for the reference.")
+    parser.add_argument("test", help="Working directory for the test-setting.")
+
+    res = parser.parse_args()
+
+    step_lists = get_seq_steplist([res.ref, res.test])
+    comparable_steps = prune_and_match(step_lists)
+
+    bp = op.commonpath([res.ref, res.test])
+    pdiffs = [op.relpath(p, bp) for p in [res.ref, res.test]]
+
+    file_hashes = md5_compare(comparable_steps, bp, pdiffs)
+
+    flag_differences(file_hashes)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
Provides a utility for crawling C-PAC working directories and comparing the outputs across runs. It is intended to spot the location of differences in processing for runs that should be identical.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
The tool does the following:
1. Accepts two working directories as input (though if the module is imported, this can be extensibly increased)
2. Grabs all numbered-node directories and sorts them
3. Grabs all output files generated from each node, as enumerated in the `_report/report.rst`
4. Computes the MD5 hash of each file
5. Compares the MD5 hashes of files from each test condition to the reference (first) condition.

It can be called as follows:

```bash
$ python spot_the_difference.py /tmp/exec-ref/workdir/cpac_11111_1/ /tmp/exec-test1/workdir/cpac_11111_1/
```

## Checklist
<!-- Replace  the [ ] with [x] to check the boxes. -->
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`).
- [x] My pull request targets the `master` branch of the repository. <!-- Change this branch if you're targeting a branch other than `develop` -->
- [x] My commit messages follow best practices.
- [x] My code follows the established code style of the repository.
- [ ] I added tests for the changes I made (if applicable).
- [ ] I updated the changelog.
- [ ] I added or updated documentation (if applicable).
- [x] I tried running the project locally and verified that there are no visible errors.

## Developer Certificate of Origin
<!-- You must read and understand the following attestation. -->

<details>
<summary>Developer Certificate of Origin</summary>

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>
